### PR TITLE
TestRes 型の定義を変更し、持たせる情報量を増やした。またこの変更による戻り値の修正を含む

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,11 +12,11 @@ const REGEX_FOR_DETECTING_COMMAND = /(<!--\s*assert[-_]codeblock\s+)(.*?)(\s*-->
 export function inspect_codeblock(textbook_filepath: string, config: { src: string }): boolean {
   let all_success = true;
   const results = inspect_codeblock_and_return_message(textbook_filepath, config);
-  for (const { is_success, message, additionally } of results) {
+  for (const { is_success, body, additionally } of results) {
     if (is_success) {
-      console.log(`\x1b[32m${message}\x1b[0m`);
+      console.log(`\x1b[32m${body.message}\x1b[0m`);
     } else {
-      console.log(`\x1b[31m${message}\x1b[0m`);
+      console.log(`\x1b[31m${body.message}\x1b[0m`);
     }
 
     if (additionally) {
@@ -34,7 +34,12 @@ export function inspect_codeblock_and_return_message(textbook_filepath: string, 
   if (!fs.existsSync(textbook_filepath)) {
     return [{
       is_success: false,
-      message: ` INCORRECT TEXTBOOK FILEPATH "${textbook_filepath}"`
+      body: {
+        command_type: "Undefined",
+        result_type: "FileNotFound",
+        message: `INCORRECT TEXTBOOK FILEPATH "${textbook_filepath}"`,
+        textbook_filepath: textbook_filepath
+      }
     }];
   }
   const textbook_content = fs.readFileSync(textbook_filepath, { encoding: "utf-8" }).replace(/\r?\n/g, "\n");
@@ -58,7 +63,14 @@ export function inspect_codeblock_and_return_message(textbook_filepath: string, 
     } else {
       return [{
         is_success: false,
-        message: ` MISMATCH FOUND: コマンド "partial ${remaining_args}" には行番号が ${expected_topnum} から始まると書いてありますが、直前の topnum= には行番号が ${actual_topnum} から始まると書いてあります`
+        body: {
+          command_type: "Partial",
+          result_type: "LineNumMismatch",
+          message: `MISMATCH FOUND: コマンド "partial ${remaining_args}" には行番号が ${expected_topnum} から始まると書いてありますが、直前の topnum= には行番号が ${actual_topnum} から始まると書いてあります`,
+          textbook_filepath: textbook_filepath,
+          expected_topnum,
+          actual_topnum
+        }
       }];
     }
   });
@@ -82,14 +94,14 @@ export function run_all_tests(textbook_filepath_arr: string[], config: { src: st
 
   for (const filepath of textbook_filepath_arr) {
     const results = inspect_codeblock_and_return_message(filepath, config);
-    for (const { is_success, message, additionally } of results) {
+    for (const { is_success, body, additionally } of results) {
       count_all++;
 
       if (is_success) {
         count_success++;
-        console.log(`\x1b[32m${message}\x1b[0m`);
+        console.log(`\x1b[32m${body.message}\x1b[0m`);
       } else {
-        console.log(`\x1b[31m${message}\x1b[0m`);
+        console.log(`\x1b[31m${body.message}\x1b[0m`);
       }
 
       if (additionally) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import { run_command_and_get_result } from "./command";
 import { TestRes } from "./util";
 const Enquirer = require('enquirer');
 
+export { run_command_and_get_result };
+
 const REGEX_FOR_DETECTING_COMMAND_AND_CODEBLOCK = /<!--\s*assert[-_]codeblock\s+(.*?)-->[\n\s]*(?<code_fence>`{3,}|~{3,})([\w\d -.]*?)\n([\s\S]*?)\k<code_fence>/gm;
 const REGEX_FOR_DETECTING_COMMAND = /(<!--\s*assert[-_]codeblock\s+)(.*?)(\s*-->)/gm;
 
@@ -219,4 +221,3 @@ export async function rename_src_files(
   }
   console.log("\x1b[34m assert-codeblock: ✅教材内の置き換えを完了しました。\x1b[0m");
 }
-

--- a/src/util.ts
+++ b/src/util.ts
@@ -14,7 +14,23 @@ Cannot find a file "${file_name}" mentioned in the code block labeled "${code_bl
   return fs.readFileSync(file_name, { encoding: "utf-8" });
 }
 
-export type TestRes = { is_success: Boolean, message: string, additionally?: unknown };
+export type CommandType = "Exact" | "Diff" | "Partial" | "DiffPartial" | "Undefined";
+export type ResultType = "Success" | "Mismatch" | "FileNotFound" | "WrongFileNameInCommand" | "LineNumMismatch" | "LineNumMissing" | "UnknownCommand" | "UnknownError";
+
+export type ResBody = {
+  command_type: CommandType,
+  result_type: ResultType,
+  message: string,
+  textbook_filepath: string,
+  message_except_content?:string,
+  codeblock_label?: string,
+  textbook_content?: string,
+  sample_content?: string,
+  textbook_topnum?: string,
+  sample_topnum?: string,
+}
+
+export type TestRes = { is_success: Boolean, body: ResBody, additionally?: unknown };
 
 export function trimEndOnAllLines(str: string) {
   return str.split("\n").map(line => line.trimEnd()).join("\n");

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,7 +15,7 @@ Cannot find a file "${file_name}" mentioned in the code block labeled "${code_bl
 }
 
 export type CommandType = "Exact" | "Diff" | "Partial" | "DiffPartial" | "Undefined";
-export type ResultType = "Success" | "Mismatch" | "FileNotFound" | "WrongFileNameInCommand" | "LineNumMismatch" | "LineNumMissing" | "UnknownCommand" | "UnknownError";
+export type ResultType = "Success" | "Mismatch" | "TextbookNotFound" | "WrongFileNameInCommand" | "LineNumMismatch" | "LineNumMissing" | "UnknownCommand" | "UnknownError";
 
 export type ResBody = {
   command_type: CommandType,

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,6 +22,7 @@ export type ResBody = {
   result_type: ResultType,
   message: string,
   textbook_filepath: string,
+  codeblock_matched_index: number,
   message_except_content?:string,
   codeblock_label?: string,
   textbook_content?: string,


### PR DESCRIPTION
resolves #12 
resolves #21 
resolves #14 

主な修正は以下の通りです。

- CI やローカル上での他のスクリプトと連携させた場合の取り回しの良さを考え、実行結果として得られる情報量を細分化しました。(#12) https://github.com/progedu/assert-codeblock-dwango-progedu/pull/18/commits/3e264ea26af75f693dc66592e26b8c6969f986a3
- CI での利便性を考えてラベル単体での検査を行えるよう、ラベル単体検査を行う関数を外部公開しました。 (#21)https://github.com/progedu/assert-codeblock-dwango-progedu/pull/18/commits/0a184095a5d140c054e6c52da0580fa3c541c512
- 指摘されているラベルの場所を特定できるように正規表現の結果から得られたインデックスを戻り値に含めました。  (#14)https://github.com/progedu/assert-codeblock-dwango-progedu/pull/18/commits/93878f12864c27db6a645fe87de967f81ba2fd5b

ご確認のほどよろしくお願いいたします 🙇 