### PR TITLE
config の型を定義した上で一部のログ出力を無効化するオプションを追加した

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -1,4 +1,4 @@
-import { FILTER, TestRes, WrongFileNameInCommandError, readFileSync, trimEndOnAllLines } from "./util";
+import { Config, FILTER, TestRes, WrongFileNameInCommandError, readFileSync, trimEndOnAllLines } from "./util";
 import { structuredPatch } from 'diff';
 import { PatchApplyError, apply_diff, apply_diff_on_lines } from "./apply_diff";
 
@@ -205,7 +205,7 @@ The content in the textbook, intended to be the partial diff, is as follows: \n\
 
 
 
-export function run_command_and_get_result(textbook_filepath: string, command: string, matched_file_content: string, config: { src: string }): TestRes {
+export function run_command_and_get_result(textbook_filepath: string, command: string, matched_file_content: string, config: Config): TestRes {
   try {
     const command_args = command.trim().split(/\s+/);
     if (command_args[0] === "exact") {

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,6 +16,11 @@ Cannot find a file "${file_name}" mentioned in the code block labeled "${code_bl
 
 export type TestRes = { is_success: Boolean, message: string, additionally?: unknown };
 
+export type Config = {
+  src: string;
+  is_quiet?: boolean;
+};
+
 export function trimEndOnAllLines(str: string) {
   return str.split("\n").map(line => line.trimEnd()).join("\n");
 }


### PR DESCRIPTION
resolves #13 

CI 上の動作における都合を考え、CI においてよく使われるであろう関数内のログを無効化できるようにしました。

- config の型を定義し、引数の型指定をこれを利用したものに変更しました
- Config のプロパティにオプショナルな Boolean 型の `is_quiet` を追加して一部のログ出力を無効化するようにしました。