### PR TITLE
ラベルのインデックスではなく行番号を返すように変更、また行数指定が数値で与えられなかった場合の挙動を変更

### DIFF
--- a/src/apply_diff.ts
+++ b/src/apply_diff.ts
@@ -36,6 +36,10 @@ export function apply_diff_on_lines(old_str_lines: string[], diff_lines: string[
       i++;
       j++;
     } else if (diff_lines[i][0] === " ") { // keep as is
+      // check that the line kept as is is correct
+      if (diff_lines[i].slice(1) !== old_str_lines[j].trimEnd()) {
+        throw new PatchApplyError(`The diff patch (in line ${i + 1}) expects the line \`${diff_lines[i].slice(1)}\` to be kept as is, but the actual line (on line ${j + 1}) is \`${old_str_lines[j]}\``)
+      }
       ans_lines.push(old_str_lines[j]);
       i++;
       j++;

--- a/src/command.ts
+++ b/src/command.ts
@@ -4,7 +4,7 @@ import { Config, FILTER, TestRes, WrongFileNameInCommandError, readFileSync, tri
 import { structuredPatch } from 'diff';
 import { PatchApplyError, apply_diff, apply_diff_on_lines } from "./apply_diff";
 
-function handle_exact(textbook_filepath: string, command_args: string[], matched_file_content: string, src_folder: string, matched_label_index: number): TestRes {
+function handle_exact(textbook_filepath: string, command_args: string[], matched_file_content: string, src_folder: string, matched_label_line_num: number): TestRes {
   const sample_file_name = command_args[1];
   const sample_file_path = src_folder + sample_file_name;
   const sample_file_content = readFileSync(sample_file_path, command_args.join(" ")).replace(/\r?\n/g, "\n");
@@ -19,7 +19,7 @@ in ${textbook_filepath}
 with the code block labeled ${sample_file_name}
 Please compare the textbook with the content of ${sample_file_path} `,
         textbook_filepath: textbook_filepath,
-        codeblock_matched_index: matched_label_index,
+        codeblock_line_num: matched_label_line_num,
         codeblock_label: command_args.join(" "),
         textbook_content: matched_file_content,
         sample_content: sample_file_content,
@@ -33,14 +33,14 @@ Please compare the textbook with the content of ${sample_file_path} `,
         result_type: "Success",
         message: ` OK: "${textbook_filepath}" のコードブロック "exact ${sample_file_name}" は "${sample_file_path}" と一致しています`,
         textbook_filepath: textbook_filepath,
-        codeblock_matched_index: matched_label_index,
+        codeblock_line_num: matched_label_line_num,
         codeblock_label: command_args.join(" "),
       }
     };
   }
 }
 
-function handle_diff(textbook_filepath: string, command_args: string[], expected_diff: string, src_folder: string, matched_label_index: number): TestRes {
+function handle_diff(textbook_filepath: string, command_args: string[], expected_diff: string, src_folder: string, matched_label_line_num: number): TestRes {
   const old_sample_file_name = command_args[1];
   const new_sample_file_name = command_args[2];
   const old_sample_file_path = path.join(src_folder, old_sample_file_name);
@@ -73,7 +73,7 @@ function handle_diff(textbook_filepath: string, command_args: string[], expected
           result_type: "Success",
           message: ` OK: "${textbook_filepath}" のコードブロック "diff ${old_sample_file_name} ${new_sample_file_name}" を "${old_sample_file_path}" に適用すると "${new_sample_file_path}" と一致しています`,
           textbook_filepath: textbook_filepath,
-          codeblock_matched_index: matched_label_index,
+          codeblock_line_num: matched_label_line_num,
         }
       };
     } else if (trimEndOnAllLines(expected_diff) === trimEndOnAllLines(actual_diff)) {
@@ -85,7 +85,7 @@ function handle_diff(textbook_filepath: string, command_args: string[], expected
           result_type: "Success",
           message: ` OK: "${textbook_filepath}" のコードブロック "diff ${old_sample_file_name} ${new_sample_file_name}" は "${old_sample_file_path}" と "${new_sample_file_path}" の diff と一致しています`,
           textbook_filepath: textbook_filepath,
-          codeblock_matched_index: matched_label_index,
+          codeblock_line_num: matched_label_line_num,
         }
       };
     } else {
@@ -100,7 +100,7 @@ with the code block labeled "diff ${old_sample_file_name} ${new_sample_file_name
 The diff of ${old_sample_file_path} with ${new_sample_file_path} is as follows: \n\`\`\`\n${actual_diff}\`\`\`
 But the content in the textbook is as follows: \n\`\`\`\n${expected_diff}\`\`\` `,
           textbook_filepath: textbook_filepath,
-          codeblock_matched_index: matched_label_index,
+          codeblock_line_num: matched_label_line_num,
           codeblock_label: code_block_label,
           textbook_content: expected_diff,
           sample_content: actual_diff,
@@ -125,7 +125,7 @@ But the content in the textbook is as follows: \n\`\`\`\n${expected_diff}\`\`\` 
 in ${textbook_filepath}
 with the code block labeled "diff ${old_sample_file_name} ${new_sample_file_name}"`,
           textbook_filepath: textbook_filepath,
-          codeblock_matched_index: matched_label_index,
+          codeblock_line_num: matched_label_line_num,
           codeblock_label: code_block_label,
           textbook_content: expected_diff,
           sample_content: actual_diff,
@@ -135,7 +135,7 @@ with the code block labeled "diff ${old_sample_file_name} ${new_sample_file_name
   }
 }
 
-function handle_partial(textbook_filepath: string, command_args: string[], matched_file_content: string, src_folder: string, matched_label_index: number): TestRes {
+function handle_partial(textbook_filepath: string, command_args: string[], matched_file_content: string, src_folder: string, matched_label_line_num: number): TestRes {
   if (command_args[2] === undefined) {
     return {
       is_success: false,
@@ -148,7 +148,7 @@ with the code block labeled "${command_args.join(" ")}"\
 Note that 'assert-codeblock partial' requires a file name AND its line number:
 for example, <!-- assert-codeblock partial 1-1.py 4 --> `,
         textbook_filepath: textbook_filepath,
-        codeblock_matched_index: matched_label_index,
+        codeblock_line_num: matched_label_line_num,
         codeblock_label: command_args.join(" "),
       }
     }
@@ -177,7 +177,7 @@ in ${textbook_filepath}
 with the code block labeled "partial ${sample_file_name} ${starting_line_num}"
 Please compare the textbook with the content of ${sample_file_path} `,
         textbook_filepath: textbook_filepath,
-        codeblock_matched_index: matched_label_index,
+        codeblock_line_num: matched_label_line_num,
         codeblock_label: command_args.join(" "),
         textbook_content: matched_file_content,
         sample_content: partial_content,
@@ -192,14 +192,14 @@ Please compare the textbook with the content of ${sample_file_path} `,
         result_type: "Success",
         message: ` OK: "${textbook_filepath}" のコードブロック "partial ${sample_file_name} ${starting_line_num}" は "${sample_file_path}" の ${starting_line_num} 行目からの ${行数} 行と一致しています`,
         textbook_filepath: textbook_filepath,
-        codeblock_matched_index: matched_label_index,
+        codeblock_line_num: matched_label_line_num,
         codeblock_label: command_args.join(" "),
       }
     };
   }
 }
 
-function handle_diff_partial(textbook_filepath: string, command_args: string[], expected_diff: string, src_folder: string, matched_label_index:number): TestRes {
+function handle_diff_partial(textbook_filepath: string, command_args: string[], expected_diff: string, src_folder: string, matched_label_line_num:number): TestRes {
   const old_sample_file_name = command_args[1];
   const new_sample_file_name = command_args[2];
   if (command_args[3] === undefined) {
@@ -215,7 +215,7 @@ Note that 'assert-codeblock diff-partial' requires two file names AND one or two
 for example, <!-- assert-codeblock diff-partial 1-1.py 1-2.py 13 -->, in which the old and the new line numbers both start at 13,
 or <!-- assert-codeblock diff-partial 1-1.py 1-2.py 13 14 -->, in which the old line number starts at 13 but the new one starts at 14.`,
         textbook_filepath: textbook_filepath,
-        codeblock_matched_index: matched_label_index,
+        codeblock_line_num: matched_label_line_num,
         codeblock_label: command_args.join(" "),
       },
     }
@@ -256,7 +256,7 @@ or <!-- assert-codeblock diff-partial 1-1.py 1-2.py 13 14 -->, in which the old 
           result_type: "Success",
           message: ` OK: "${textbook_filepath}" のコードブロック "${command_args.join(" ")}" を "${old_sample_file_path}" の ${old_starting_line_num + 1} 行目からに適用すると "${new_sample_file_path}" の ${starting_line_num + 1} 行目からと一致しています`,
           textbook_filepath: textbook_filepath,
-          codeblock_matched_index: matched_label_index,
+          codeblock_line_num: matched_label_line_num,
         }
       };
     } else {
@@ -292,7 +292,7 @@ which does not start with \`expected_newStr_lines.join("\n")\`, which is
 ${expected_newStr_lines.join("\n")}\`\`\`
 **************************************`,
           textbook_filepath: textbook_filepath,
-          codeblock_matched_index: matched_label_index,
+          codeblock_line_num: matched_label_line_num,
           codeblock_label: code_block_label,
           textbook_content: expected_diff,
           sample_content: entire_diff,
@@ -317,7 +317,7 @@ The content in the textbook, intended to be the partial diff, is as follows: \n\
 in ${textbook_filepath}
 with the code block labeled "${command_args.join(" ")}"`,
           textbook_filepath: textbook_filepath,
-          codeblock_matched_index: matched_label_index,
+          codeblock_line_num: matched_label_line_num,
           codeblock_label: code_block_label,
           textbook_content: expected_diff,
           sample_content: entire_diff,
@@ -330,17 +330,17 @@ with the code block labeled "${command_args.join(" ")}"`,
 
 
 
-export function run_command_and_get_result(textbook_filepath: string, command: string, matched_file_content: string, config: Config, index:number=-1): TestRes {
+export function run_command_and_get_result(textbook_filepath: string, command: string, matched_file_content: string, config: Config, matched_line_num:number=-1): TestRes {
   try {
     const command_args = command.trim().split(/\s+/);
     if (command_args[0] === "exact") {
-      return handle_exact(textbook_filepath, command_args, matched_file_content, config.src, index);
+      return handle_exact(textbook_filepath, command_args, matched_file_content, config.src, matched_line_num);
     } else if (command_args[0] === "diff") {
-      return handle_diff(textbook_filepath, command_args, matched_file_content, config.src, index);
+      return handle_diff(textbook_filepath, command_args, matched_file_content, config.src, matched_line_num);
     } else if (command_args[0] === "partial") {
-      return handle_partial(textbook_filepath, command_args, matched_file_content, config.src, index);
+      return handle_partial(textbook_filepath, command_args, matched_file_content, config.src, matched_line_num);
     } else if (command_args[0] === "diff-partial") {
-      return handle_diff_partial(textbook_filepath, command_args, matched_file_content, config.src, index);
+      return handle_diff_partial(textbook_filepath, command_args, matched_file_content, config.src, matched_line_num);
     } else {
       return {
         is_success: false,
@@ -349,7 +349,7 @@ export function run_command_and_get_result(textbook_filepath: string, command: s
           result_type: "UnknownCommand",
           message: ` assert-codeblock は ${JSON.stringify(command)} というコマンドをサポートしていません`,
           textbook_filepath: textbook_filepath,
-          codeblock_matched_index: index,
+          codeblock_line_num: matched_line_num,
           codeblock_label: command,
         }
       };
@@ -363,7 +363,7 @@ export function run_command_and_get_result(textbook_filepath: string, command: s
           result_type: "WrongFileNameInCommand",
           message: e.message,
           textbook_filepath: textbook_filepath,
-          codeblock_matched_index: index,
+          codeblock_line_num: matched_line_num,
           codeblock_label: command,
         }
       };

--- a/src/command.ts
+++ b/src/command.ts
@@ -153,7 +153,27 @@ for example, <!-- assert-codeblock partial 1-1.py 4 --> `,
       }
     }
   }
+
   const starting_line_num = Number(command_args[2]);
+
+  if (Number.isNaN(starting_line_num)) {
+    return {
+      is_success: false,
+      body: {
+        command_type: "Partial",
+        result_type: "LineNumNotNumber",
+        message: ` LINE NUMBER IS NOT A NUMBER
+in ${textbook_filepath}:${matched_label_line_num}
+with the code block labeled "${command_args.join(" ")}"
+The line number "${command_args[2]}" is not a number`,
+        textbook_filepath: textbook_filepath,
+        codeblock_line_num: matched_label_line_num,
+        codeblock_label: command_args.join(" "),
+      }
+    }
+  }
+
+
   const sample_file_name = command_args[1];
   const sample_file_path = path.join(src_folder , sample_file_name);
   const sample_file_content = readFileSync(sample_file_path, command_args.join(" "), matched_label_line_num).replace(/\r?\n/g, "\n");
@@ -222,6 +242,40 @@ or <!-- assert-codeblock diff-partial 1-1.py 1-2.py 13 14 -->, in which the old 
   }
   const starting_line_num = Number(command_args[3]) - 1;
   const old_starting_line_num = command_args[4] === undefined ? starting_line_num : Number(command_args[4]) - 1;
+
+  if (Number.isNaN(starting_line_num) || Number.isNaN(old_starting_line_num)) {
+    let mes = "";
+    const is_starting_line_num_not_number = Number.isNaN(starting_line_num);
+    const is_old_starting_line_num_not_number = Number.isNaN(old_starting_line_num);
+
+    if (command_args[4] === undefined) {
+      // topnum が 1 つの場合
+      mes = `The line number "${command_args[3]}" is not a number`;
+    } else {
+      // topnum が 2 つの場合
+      if (is_starting_line_num_not_number && is_old_starting_line_num_not_number) {
+        mes = `The line numbers "${command_args[3]}" and "${command_args[4]}" are not numbers`;
+      } else if (is_starting_line_num_not_number) {
+        mes = `The new topnum "${command_args[3]}" is not a number`;
+      } else {
+        mes = `The old topnum "${command_args[4]}" is not a number`;
+      }
+    }
+    return {
+      is_success: false,
+      body: {
+        command_type: "Partial",
+        result_type: "LineNumNotNumber",
+        message: ` LINE NUMBER IS NOT A NUMBER
+in ${textbook_filepath}:${matched_label_line_num}
+with the code block labeled "${command_args.join(" ")}"
+${mes}`,
+        textbook_filepath: textbook_filepath,
+        codeblock_line_num: matched_label_line_num,
+        codeblock_label: command_args.join(" "),
+      }
+    }
+  }
 
   const old_sample_file_path = path.join(src_folder , old_sample_file_name);
   const new_sample_file_path = path.join(src_folder , new_sample_file_name);

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ export function inspect_codeblock_and_return_message(textbook_filepath: string, 
         body: {
           command_type: "Partial",
           result_type: "LineNumMismatch",
-          message: `MISMATCH FOUND: コマンド "partial ${remaining_args}" には行番号が ${expected_topnum} から始まると書いてありますが、直前の topnum= には行番号が ${actual_topnum} から始まると書いてあります`,
+          message: ` MISMATCH FOUND in ${textbook_filepath}:${line_num}: コマンド "partial ${remaining_args}" には行番号が ${expected_topnum} から始まると書いてありますが、直前の topnum= には行番号が ${actual_topnum} から始まると書いてあります`,
           textbook_filepath: textbook_filepath,
           codeblock_line_num: line_num,
           codeblock_label: "partial " + remaining_args,

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,10 +47,11 @@ export function inspect_codeblock_and_return_message(textbook_filepath: string, 
   }
   const textbook_content = fs.readFileSync(textbook_filepath, { encoding: "utf-8" }).replace(/\r?\n/g, "\n");
 
+  // 改行の位置を特定
+  const lf_arr = [...textbook_content.matchAll(/\n/g)].map((x) => x.index);
+
   /* partial に書いてある先頭行番号が 直前の topnum= に書いてある行番号と異なっていたら怒る */
   const whether_consistent_with_topnum = [...textbook_content.matchAll(/topnum\s*=\s*(?<topnum>"\d+"|'\d+'|\d+)[^>]*>[\n\s]*<!--\s*assert[-_]codeblock\s+partial\s+(?<remaining_args>.*?)-->/gm)];
-
-  const lf_arr = [...textbook_content.matchAll(/\n/g)].map((x) => x.index);
 
   // 怒りを蓄えるための配列
   const inconsistent_topnum_msg: TestRes[] = whether_consistent_with_topnum.flatMap(a => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,7 +22,7 @@ export type ResBody = {
   result_type: ResultType,
   message: string,
   textbook_filepath: string,
-  codeblock_matched_index: number,
+  codeblock_line_num: number,
   message_except_content?:string,
   codeblock_label?: string,
   textbook_content?: string,

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,10 +6,10 @@ export class WrongFileNameInCommandError extends Error {
   }
 }
 
-export function readFileSync(file_name: string, code_block_label: string): string {
+export function readFileSync(file_name: string, code_block_label: string, line_num:number): string {
   if (!fs.existsSync(file_name)) {
     throw new WrongFileNameInCommandError(` FILE NOT FOUND 
-Cannot find a file "${file_name}" mentioned in the code block labeled "${code_block_label}" `);
+Cannot find a file "${file_name}" mentioned in the code block labeled "${code_block_label}" at line:${line_num}`);
   }
   return fs.readFileSync(file_name, { encoding: "utf-8" });
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,7 +15,7 @@ Cannot find a file "${file_name}" mentioned in the code block labeled "${code_bl
 }
 
 export type CommandType = "Exact" | "Diff" | "Partial" | "DiffPartial" | "Undefined";
-export type ResultType = "Success" | "Mismatch" | "TextbookNotFound" | "WrongFileNameInCommand" | "LineNumMismatch" | "LineNumMissing" | "UnknownCommand" | "UnknownError";
+export type ResultType = "Success" | "Mismatch" | "TextbookNotFound" | "WrongFileNameInCommand" | "LineNumMismatch" | "LineNumMissing" | "LineNumNotNumber" | "UnknownCommand" | "UnknownError";
 
 export type ResBody = {
   command_type: CommandType,


### PR DESCRIPTION
resolves #27 
fix #8 
fix #16 

- ラベルの存在する文字列中のインデックスではなく、行番号を返すように変更しました。
  -これに伴ってメッセージに行番号を含めるようにしました。
- 行数指定が数値でない場合に `Number()` が `NaN` と返してきたらエラーとなるように変更しました。(関連 #8 )
- 行の始まりが空白である場合に、サンプルファイルと教材を比較して相違があればエラーを吐くように変更しました。(#16)


コンフリクトの解消がちょっと面倒そうだったので #27 と #8 、#16 の内容をまとめて変更しました 🙇 